### PR TITLE
Increase number of saved configs (SAVEAREA_MAX) if SD card is not used - put CONFIG in safer flash position

### DIFF
--- a/data_storage.c
+++ b/data_storage.c
@@ -24,7 +24,7 @@
 #include <string.h>
 
 uint16_t lastsaveid = 0;
-#if SAVEAREA_MAX >= 8
+#if SAVEAREA_MAX > 8
 #error "Increase checksum_ok type for save more cache slots"
 #endif
 // properties CRC check cache (max 8 slots)

--- a/data_storage.c
+++ b/data_storage.c
@@ -76,8 +76,8 @@ caldata_save(uint32_t id)
   current_props.magic = PROPS_MAGIC;
   current_props.checksum = checksum(&current_props, sizeof current_props - sizeof current_props.checksum);
 
-  // write to flash
-  uint16_t *dst = (uint16_t*)(SAVE_PROP_CONFIG_ADDR + id * SAVE_PROP_CONFIG_SIZE);
+  // write to flash (id: top-down)
+  uint16_t *dst = (uint16_t*)(SAVE_PROP_CONFIG_ADDR + (SAVEAREA_MAX - 1 - id) * SAVE_PROP_CONFIG_SIZE);
   flash_program_half_word_buffer(dst, (uint16_t*)&current_props, sizeof(properties_t));
 
   lastsaveid = id;
@@ -89,8 +89,8 @@ get_properties(uint32_t id)
 {
   if (id >= SAVEAREA_MAX)
     return NULL;
-  // point to saved area on the flash memory
-  properties_t *src = (properties_t*)(SAVE_PROP_CONFIG_ADDR + id * SAVE_PROP_CONFIG_SIZE);
+  // point to saved area on the flash memory (id: top-down)
+  properties_t *src = (properties_t*)(SAVE_PROP_CONFIG_ADDR + (SAVEAREA_MAX - 1 - id) * SAVE_PROP_CONFIG_SIZE);
   // Check crc cache mask (made it only 1 time)
   if (checksum_ok&(1<<id))
     return src;

--- a/hardware.h
+++ b/hardware.h
@@ -179,7 +179,11 @@ void initI2S(void *buffer, uint16_t count);
 
 #define FLASH_PAGESIZE 0x800
 
-#define SAVEAREA_MAX 5
+#ifdef __USE_SD_CARD__
+# define SAVEAREA_MAX 5
+#else
+# define SAVEAREA_MAX 6
+#endif
 
 // Depend from config_t size, should be aligned by FLASH_PAGESIZE
 #define SAVE_CONFIG_SIZE        0x00000800

--- a/hardware.h
+++ b/hardware.h
@@ -194,10 +194,10 @@ void initI2S(void *buffer, uint16_t count);
 // Save config_t and properties_t flash area (see flash7 from *.ld settings)
 #define SAVE_FULL_AREA_SIZE     (SAVE_CONFIG_SIZE + SAVEAREA_MAX * SAVE_PROP_CONFIG_SIZE)
 // Save setting at end of CPU flash area
-// Config at end minus full size
-#define SAVE_CONFIG_ADDR        (FLASH_START_ADDRESS + FLASH_TOTAL_SIZE - SAVE_FULL_AREA_SIZE)
-// Properties save area follow after config
-#define SAVE_PROP_CONFIG_ADDR   (SAVE_CONFIG_ADDR + SAVE_CONFIG_SIZE)
+// Config at top minus config size
+#define SAVE_CONFIG_ADDR        (FLASH_START_ADDRESS + FLASH_TOTAL_SIZE - SAVE_CONFIG_SIZE)
+// Properties save area follow below config (top down)
+#define SAVE_PROP_CONFIG_ADDR   (FLASH_START_ADDRESS + FLASH_TOTAL_SIZE - SAVE_FULL_AREA_SIZE)
 
 // Erase settings on page
 void flash_erase_pages(uint32_t page_address, uint32_t size);

--- a/hardware.h
+++ b/hardware.h
@@ -180,9 +180,9 @@ void initI2S(void *buffer, uint16_t count);
 #define FLASH_PAGESIZE 0x800
 
 #ifdef __USE_SD_CARD__
-# define SAVEAREA_MAX 5
-#else
 # define SAVEAREA_MAX 6
+#else
+# define SAVEAREA_MAX 8
 #endif
 
 // Depend from config_t size, should be aligned by FLASH_PAGESIZE

--- a/ui.c
+++ b/ui.c
@@ -1633,6 +1633,9 @@ const menuitem_t menu_save[] = {
 #if SAVEAREA_MAX > 6
   { MT_ADV_CALLBACK, 6, MT_CUSTOM_LABEL, menu_save_acb },
 #endif
+#if SAVEAREA_MAX > 7
+  { MT_ADV_CALLBACK, 7, MT_CUSTOM_LABEL, menu_save_acb },
+#endif
   { MT_NONE, 0, NULL, menu_back } // next-> menu_back
 };
 
@@ -1654,6 +1657,9 @@ const menuitem_t menu_recall[] = {
 #endif
 #if SAVEAREA_MAX > 6
   { MT_ADV_CALLBACK, 6, MT_CUSTOM_LABEL, menu_recall_acb },
+#endif
+#if SAVEAREA_MAX > 7
+  { MT_ADV_CALLBACK, 7, MT_CUSTOM_LABEL, menu_recall_acb },
 #endif
   { MT_NONE, 0, NULL, menu_back } // next-> menu_back
 };


### PR DESCRIPTION
This gives enough flash space to store 6 configs instead of 5. Store them top-down, the default (id==0) is at highest address and will not be destoyed if program flash size increases.

Signed-off-by: Martin <Ho-Ro@users.noreply.github.com>