### PR TITLE
Correct USB vendor and product string: "nanovna.com" and "NanoVNA-H" / -H4

### DIFF
--- a/usbcfg.c
+++ b/usbcfg.c
@@ -150,27 +150,34 @@ static const uint8_t vcom_string0[] = {
  * Vendor string.
  */
 static const uint8_t vcom_string1[] = {
-  USB_DESC_BYTE(38),                    /* bLength.                         */
+  USB_DESC_BYTE(24),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
-  'S', 0, 'T', 0, 'M', 0, 'i', 0, 'c', 0, 'r', 0, 'o', 0, 'e', 0,
-  'l', 0, 'e', 0, 'c', 0, 't', 0, 'r', 0, 'o', 0, 'n', 0, 'i', 0,
-  'c', 0, 's', 0
+  'n', 0, 'a', 0, 'n', 0, 'o', 0, 'v', 0, 'n', 0, 'a', 0, '.', 0,
+  'c', 0, 'o', 0, 'm', 0
 };
 
+#ifdef NANOVNA_F303
 /*
  * Device Description string.
  */
 static const uint8_t vcom_string2[] = {
-  USB_DESC_BYTE(56),                    /* bLength.                         */
+  USB_DESC_BYTE(22),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
-  'C', 0, 'h', 0, 'i', 0, 'b', 0, 'i', 0, 'O', 0, 'S', 0, '/', 0,
-  'R', 0, 'T', 0, ' ', 0, 'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0,
-  'a', 0, 'l', 0, ' ', 0, 'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0,
-  'o', 0, 'r', 0, 't', 0
+  'N', 0, 'a', 0, 'n', 0, 'o', 0, 'V', 0, 'N', 0, 'A', 0, '-', 0, 'H', 0, '4', 0
 };
+#else
+/*
+ * Device Description string.
+ */
+static const uint8_t vcom_string2[] = {
+  USB_DESC_BYTE(20),                    /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  'N', 0, 'a', 0, 'n', 0, 'o', 0, 'V', 0, 'N', 0, 'A', 0, '-', 0, 'H', 0
+};
+#endif
 
 /*
- * Serial Number string.
+ * Serial Number string. TODO: use real product version.
  */
 static const uint8_t vcom_string3[] = {
   USB_DESC_BYTE(8),                     /* bLength.                         */


### PR DESCRIPTION
Instead of "STMicroelectronics" and "ChibiOS/RT Virtual COM Port"

The `usbcfg.c` uses still the strings from the demo code.