### PR TITLE
Digital RTC calibration

### DIFF
--- a/hardware.h
+++ b/hardware.h
@@ -114,6 +114,11 @@ uint32_t rtc_get_dr_bin(void);
 uint32_t rtc_get_FAT(void);
 // Write date and time (need in bcd format!!!)
 void rtc_set_time(uint32_t dr, uint32_t tr);
+bool rtc_clock_output_enabled(void);
+void rtc_clock_output_enable(bool en);
+bool rtc_set_cal(int16_t ppm);
+int16_t rtc_get_cal(void);
+bool rtc_cal_pending(void);
 #endif
 
 /*

--- a/nanovna.h
+++ b/nanovna.h
@@ -796,6 +796,7 @@ enum {
 #define S_METRE    "m"     //
 #define S_VOLT     "V"     //
 #define S_AMPER    "A"     //
+#define S_PPM      "ppm"   //
 
 // Max palette indexes in config
 #define MAX_PALETTE     32


### PR DESCRIPTION
STM32 microcontrollers allow digital calibration of the real time clock frequency with a range from -487.1 to +488.5 ppm.

To facilitate calibration, it is possible to output the calibrated oscillator output (RTC_CALIB) on pin PC13. On the 2.8" NanoVNA-H this pin is wired to LED2 (blue led) via the 1k R3 resistor, which is easy to probe with an oscilloscope or frequency counter.

Expose both features in the "RTC CAL" submenu under "EXPERT SETTINGS"